### PR TITLE
Adds protocol buffer definitions for user input metadata

### DIFF
--- a/proto/audio_element.proto
+++ b/proto/audio_element.proto
@@ -1,0 +1,54 @@
+syntax = "proto2";
+
+package libiamf_proto;
+
+import "param_definitions.proto";
+
+enum AudioElementType {
+  AUDIO_ELEMENT_INVALID = 0;
+  AUDIO_ELEMENT_CHANNEL_BASED = 1;
+  AUDIO_ELEMENT_SCENE_BASED = 2;
+}
+
+message AudioElementParam {
+  optional uint32 param_definition_type = 1;
+  oneof param_definition {
+    DemixingParamDefinition demixing_param = 2;
+    ReconGainParamDefinition recon_gain_param = 3;
+  }
+}
+
+message ChannelAudioLayerConfig {
+  optional uint32 loudspeaker_layout = 1;
+  optional uint32 output_gain_is_present_flag = 2;
+  optional uint32 recon_gain_is_present_flag = 3;
+  optional uint32 reserved_a = 4;
+  optional uint32 substream_count = 5;
+  optional uint32 coupled_substream_count = 6;
+  optional uint32 output_gain_flag = 7;
+  optional uint32 reserved_b = 8;
+  optional int32 output_gain = 9;
+}
+
+message ScalableChannelLayoutConfig {
+  optional uint32 num_layers = 1;
+  optional uint32 reserved = 2;
+  repeated ChannelAudioLayerConfig channel_audio_layer_configs = 3;
+}
+
+message AmbisonicsConfig {}
+
+message AudioElementObuMetadata {
+  optional uint32 audio_element_id = 1;
+  optional AudioElementType audio_element_type = 2;
+  optional uint32 reserved = 3;
+  optional uint32 codec_config_id = 4;
+  optional uint32 num_substreams = 5;
+  repeated uint32 audio_substream_ids = 6 [packed = true];
+  optional uint32 num_parameters = 7;
+  repeated AudioElementParam audio_element_params = 8;
+  oneof config {
+    ScalableChannelLayoutConfig scalable_channel_layout_config = 9;
+    AmbisonicsConfig ambisonics_config = 10;
+  }
+}

--- a/proto/audio_frame.proto
+++ b/proto/audio_frame.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+
+package libiamf_proto;
+
+message SubstreamMetadata {
+  repeated uint32 channel_ids = 1 [packed = true];
+}
+
+message AudioFrameObuMetadata {
+  optional string wav_filename = 1;
+  map<uint32, SubstreamMetadata> substream_metadata = 2;
+
+  // Order of substream IDs in one AudioFrameObu.
+  repeated uint32 substream_id_ordering = 3 [packed = true];
+  optional uint32 samples_to_trim_at_end = 4;
+  optional uint32 samples_to_trim_at_start = 5;
+}

--- a/proto/codec_config.proto
+++ b/proto/codec_config.proto
@@ -1,0 +1,47 @@
+syntax = "proto2";
+
+package libiamf_proto;
+
+// Valid proto enums start at index 1, which are different from the
+// corresponding enums in C, e.g. kLpcmBigEndian = 0.
+enum LpcmFormatFlags {
+  LPCM_INVALID = 0;
+  LPCM_BIG_ENDIAN = 1;
+  LPCM_LITTLE_ENDIAN = 2;
+}
+
+message DecoderConfigLpcm {
+  optional LpcmFormatFlags sample_format_flags = 1;
+  optional uint32 sample_size = 2;
+  optional uint32 sample_rate = 3;
+}
+
+message DecoderConfigOpus {
+  optional uint32 version = 1;
+  optional uint32 output_channel_count = 2;
+  optional uint32 pre_skip = 3;
+  optional uint32 input_sample_rate = 4;
+  optional int32 output_gain = 5;
+  optional uint32 mapping_family = 6;
+}
+
+message DecoderConfigAac {}
+
+message DecoderConfigFlac {}
+
+message CodecConfig {
+  optional uint32 codec_id = 1;
+  optional uint32 num_samples_per_frame = 2;
+  optional int32 roll_distance = 3;
+  oneof decoder_config {
+    DecoderConfigLpcm decoder_config_lpcm = 5;
+    DecoderConfigOpus decoder_config_opus = 6;
+    DecoderConfigAac decoder_config_aac = 7;
+    DecoderConfigFlac decoder_config_flac = 8;
+  }
+}
+
+message CodecConfigObuMetadata {
+  optional uint32 codec_config_id = 1;
+  optional CodecConfig codec_config = 2;
+}

--- a/proto/magic_code.proto
+++ b/proto/magic_code.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+package libiamf_proto;
+
+message MagicCodeObuMetadata {
+  optional uint32 ia_code = 1;
+  optional uint32 version = 2;
+  optional uint32 profile_version = 3;
+}

--- a/proto/mix_presentation.proto
+++ b/proto/mix_presentation.proto
@@ -1,0 +1,102 @@
+syntax = "proto2";
+
+package libiamf_proto;
+
+import "param_definitions.proto";
+
+message MixPresentationAnnotations {
+  optional string mix_presentation_friendly_label = 1;
+}
+
+message MixPresentationElementAnnotations {
+  optional string audio_element_friendly_label = 1;
+}
+
+message ElementMixConfig {
+  optional MixGainParamDefinition mix_gain = 1;
+}
+
+message SubMixAudioElement {
+  optional uint32 audio_element_id = 1;
+  optional MixPresentationElementAnnotations
+      mix_presentation_element_annotations = 2;
+  // RenderingConfig has no payload.
+  optional ElementMixConfig element_mix_config = 3;
+}
+
+message LoudspeakersSPLabelLayout {
+  optional uint32 num_loudspeakers = 1;
+  repeated uint32 sp_label = 2 [packed = true];
+}
+
+message OutputMixConfig {
+  optional MixGainParamDefinition output_mix_gain = 1;
+}
+
+enum SoundSystem {
+  SOUND_SYSTEM_INVALID = 0;
+  SOUND_SYSTEM_A_0_2_0 = 1;
+  SOUND_SYSTEM_B_0_5_0 = 2;
+  SOUND_SYSTEM_C_2_5_0 = 3;
+  SOUND_SYSTEM_D_4_5_0 = 4;
+  SOUND_SYSTEM_E_4_5_1 = 5;
+  SOUND_SYSTEM_F_3_7_0 = 6;
+  SOUND_SYSTEM_G_4_9_0 = 7;
+  SOUND_SYSTEM_H_9_10_3 = 8;
+  SOUND_SYSTEM_I_0_7_0 = 9;
+  SOUND_SYSTEM_J_4_7_0 = 10;
+  SOUND_SYSTEM_10_2_7_0 = 11;
+  SOUND_SYSTEM_11_2_3_0 = 12;
+}
+
+message LoudspeakersSsConventionLayout {
+  optional SoundSystem sound_system = 1;
+  optional uint32 reserved = 2;
+}
+
+message LoudspeakersNotDefOrBinauralLayout {
+  optional uint32 reserved = 1;
+}
+
+enum LayoutType {
+  LAYOUT_TYPE_NOT_DEFINED = 0;
+  LAYOUT_TYPE_LOUDSPEAKERS_SP_LABEL = 1;
+  LAYOUT_TYPE_LOUDSPEAKERS_SS_CONVENTION = 2;
+  LAYOUT_TYPE_BINAURAL = 3;
+}
+
+message Layout {
+  optional LayoutType layout_type = 1;
+  oneof specific_layout {
+    LoudspeakersSPLabelLayout sp_layout = 2;
+    LoudspeakersSsConventionLayout ss_layout = 3;
+    LoudspeakersNotDefOrBinauralLayout not_def_binaural_layout = 4;
+  }
+}
+
+message LoudnessInfo {
+  optional uint32 info_type = 1;
+  optional int32 integrated_loudness = 2;
+  optional int32 digital_peak = 3;
+  optional int32 true_peak = 4;
+}
+
+message MixPresentationLayout {
+  optional Layout loudness_layout = 1;
+  optional LoudnessInfo loudness = 2;
+}
+
+message MixPresentationSubMix {
+  optional uint32 num_audio_elements = 1;
+  repeated SubMixAudioElement audio_elements = 2;
+  optional OutputMixConfig output_mix_config = 3;
+  optional uint32 num_layouts = 4;
+  repeated MixPresentationLayout layouts = 5;
+}
+
+message MixPresentationObuMetadata {
+  optional uint32 mix_presentation_id = 1;
+  optional MixPresentationAnnotations mix_presentation_annotations = 2;
+  optional uint32 num_sub_mixes = 3;
+  repeated MixPresentationSubMix sub_mixes = 4;
+}

--- a/proto/param_definitions.proto
+++ b/proto/param_definitions.proto
@@ -1,0 +1,27 @@
+syntax = "proto2";
+
+package libiamf_proto;
+
+message ParamDefinition {
+  optional uint32 parameter_id = 1;
+  optional uint32 parameter_rate = 2;
+  optional bool param_definition_mode = 3;
+  optional uint32 reserved = 4;
+  optional uint32 duration = 5;
+  optional uint32 num_subblocks = 6;
+  optional uint32 constant_subblock_duration = 7;
+  repeated uint32 subblock_durations = 8 [packed = true];
+}
+
+message MixGainParamDefinition {
+  optional ParamDefinition param_definition = 1;
+  optional int32 default_mix_gain = 2;
+}
+
+message DemixingParamDefinition {
+  optional ParamDefinition param_definition = 1;
+}
+
+message ReconGainParamDefinition {
+  optional ParamDefinition param_definition = 1;
+}

--- a/proto/parameter_block.proto
+++ b/proto/parameter_block.proto
@@ -1,0 +1,78 @@
+syntax = "proto2";
+
+package libiamf_proto;
+
+enum AnimationType {
+  ANIMATE_INVALID = 0;
+  ANIMATE_STEP = 1;
+  ANIMATE_LINEAR = 2;
+  ANIMATE_BEZIER = 3;
+}
+
+message AnimationStepInt16 {
+  optional int32 start_point_value = 1;
+}
+
+message AnimationLinearInt16 {
+  optional int32 start_point_value = 1;
+  optional int32 end_point_value = 2;
+}
+
+message AnimationBezierInt16 {
+  optional int32 start_point_value = 1;
+  optional int32 end_point_value = 2;
+  optional int32 control_point_value = 3;
+  optional uint32 control_point_relative_time = 4;
+}
+
+message AnimatedParameterDataInt16 {
+  oneof parameter_data {
+    AnimationStepInt16 step = 1;
+    AnimationLinearInt16 linear = 2;
+    AnimationBezierInt16 bezier = 3;
+  }
+}
+
+message MixGainParameterData {
+  optional AnimationType animation_type = 1;
+  optional AnimatedParameterDataInt16 param_data = 2;
+}
+
+enum DMixPMode {
+  DMIXP_MODE_INVALID = 0;
+  //                       (alpha, beta,  gamma, delta, w_idx_offset)
+  DMIXP_MODE_1 = 1;  //    (    1,     1, 0.707, 0.707,           -1)
+  DMIXP_MODE_2 = 2;  //    (0.707, 0.707, 0.707, 0.707,           -1)
+  DMIXP_MODE_3 = 3;  //    (    1, 0.866, 0.866, 0.866,           -1)
+  DMIXP_MODE_RESERVED_A = 4;
+  DMIXP_MODE_1_N = 5;  //  (    1,     1, 0.707, 0.707,            1)
+  DMIXP_MODE_2_N = 6;  //  (0.707, 0.707, 0.707, 0.707,            1)
+  DMIXP_MODE_3_N = 7;  //  (    1, 0.866, 0.866, 0.866,            1)
+  DMIXP_MODE_RESERVED_B = 8;
+}
+
+message DemixingInfoParameterData {
+  optional DMixPMode dmixp_mode = 1;
+  optional uint32 reserved = 2;
+}
+
+message ReconGainParameterData {
+  // TODO(b/278261571): Add support for Recon Gain Parameters.
+}
+
+message ParameterSubblock {
+  optional uint32 subblock_duration = 1;
+  oneof parameter_data {
+    MixGainParameterData mix_gain_parameter_data = 2;
+    DemixingInfoParameterData demixing_info_parameter_data = 3;
+    ReconGainParameterData recon_gain_parameter_data = 4;
+  }
+}
+
+message ParameterBlockObuMetadata {
+  optional uint32 parameter_id = 1;
+  optional uint32 duration = 2;
+  optional uint32 num_subblocks = 3;
+  optional uint32 constant_subblock_duration = 4;
+  repeated ParameterSubblock subblocks = 5;
+}

--- a/proto/sync.proto
+++ b/proto/sync.proto
@@ -1,0 +1,23 @@
+syntax = "proto2";
+
+package libiamf_proto;
+
+enum SyncObuDataType {
+  OBU_DATA_TYPE_INVALID = 0;
+  OBU_DATA_TYPE_SUBSTREAM = 1;
+  OBU_DATA_TYPE_PARAMETER = 2;
+}
+
+message SyncElement {
+  optional uint32 obu_id = 1;
+  optional SyncObuDataType obu_data_type = 2;
+  optional bool reinitialize_decoder = 3;
+  optional uint32 reserved_a = 4;
+  optional int32 relative_offset = 5;
+}
+
+message SyncObuMetadata {
+  optional uint32 global_offset = 1;
+  optional uint32 num_obu_ids = 2;
+  repeated SyncElement sync_array = 3;
+}

--- a/proto/temporal_delimiter.proto
+++ b/proto/temporal_delimiter.proto
@@ -1,0 +1,7 @@
+syntax = "proto2";
+
+package libiamf_proto;
+
+message TemporalDelimiterObuMetadata {
+  optional bool enable_temporal_delimiters = 1;
+}

--- a/proto/test_vector_metadata.proto
+++ b/proto/test_vector_metadata.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+package libiamf_proto;
+
+message TestVectorMetadata {
+  optional string human_readable_description = 1;
+  optional string file_name_prefix = 2;
+  optional bool is_valid = 3;
+  optional string mp4_fixed_timestamp = 4;
+}

--- a/proto/user_metadata.proto
+++ b/proto/user_metadata.proto
@@ -1,0 +1,25 @@
+syntax = "proto2";
+
+package libiamf_proto;
+
+import "audio_element.proto";
+import "audio_frame.proto";
+import "codec_config.proto";
+import "magic_code.proto";
+import "mix_presentation.proto";
+import "parameter_block.proto";
+import "sync.proto";
+import "temporal_delimiter.proto";
+import "test_vector_metadata.proto";
+
+message UserMetadata {
+  repeated MagicCodeObuMetadata magic_code_metadata = 1;
+  repeated CodecConfigObuMetadata codec_config_metadata = 2;
+  repeated AudioElementObuMetadata audio_element_metadata = 3;
+  repeated MixPresentationObuMetadata mix_presentation_metadata = 4;
+  repeated SyncObuMetadata sync_metadata = 5;
+  repeated AudioFrameObuMetadata audio_frame_metadata = 6;
+  repeated ParameterBlockObuMetadata parameter_block_metadata = 7;
+  optional TemporalDelimiterObuMetadata temporal_delimiter_metadata = 8;
+  optional TestVectorMetadata test_vector_metadata = 9;
+}


### PR DESCRIPTION
The `user_metadata.proto` defines the top-level message type for our *.textproto files.