### PR TITLE
Adds missing include and avoids unused variable

### DIFF
--- a/code/src/iamf_dec/IAMF_decoder.c
+++ b/code/src/iamf_dec/IAMF_decoder.c
@@ -2487,7 +2487,6 @@ int iamf_stream_renderer_enable_downmix(IAMF_StreamRenderer *sr) {
 IAMF_StreamRenderer *iamf_stream_renderer_open(IAMF_Stream *s,
                                                IAMF_MixPresentation *mp,
                                                int frame_size) {
-  ChannelLayerContext *ctx = (ChannelLayerContext *)s->priv;
   IAMF_StreamRenderer *sr = IAMF_MALLOCZ(IAMF_StreamRenderer, 1);
   if (!sr) return 0;
 
@@ -2496,6 +2495,7 @@ IAMF_StreamRenderer *iamf_stream_renderer_open(IAMF_Stream *s,
   iamf_stream_renderer_update_info(sr, mp, frame_size);
 
 #if DISABLE_BINAURALIZER == 0
+  ChannelLayerContext *ctx = (ChannelLayerContext *)s->priv;
   if (s->final_layout) {
     sr->renderer.layout = &s->final_layout->sp;
     if (s->final_layout->layout.type == IAMF_LAYOUT_TYPE_BINAURAL) {

--- a/code/src/iamf_dec/IAMF_decoder_private.h
+++ b/code/src/iamf_dec/IAMF_decoder_private.h
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 
 #include "IAMF_OBU.h"
+#include "IAMF_decoder.h"
 #include "IAMF_core_decoder.h"
 #include "IAMF_defines.h"
 #include "IAMF_types.h"


### PR DESCRIPTION
This commit fixes two small issues:

IAMF_decoder_private.h uses IAMF_extradata and IAMF_StreamInfo but does not include IAMF_decoder.h (And it does not appear to be transitively included), so this commit adds the include.

In IAMF_decoder.c, if binauralizer is disabled, there is a unused var `ctx`.  This PR moves it inside the code block where it's used to avoid that error.