### PR TITLE
Places parens to avoid precedence warning

### DIFF
--- a/code/test/tools/iamfplayer/include/a2b_endian.h
+++ b/code/test/tools/iamfplayer/include/a2b_endian.h
@@ -71,7 +71,7 @@ static inline uint16_t bswap64(const uint64_t u64) {
     ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)))
   return __builtin_bswap64(u64);
 #else
-  return bswap32(u64) + 0ULL << 32 | bswap32(u64 >> 32);
+  return (bswap32(u64) + 0ULL) << 32 | bswap32(u64 >> 32);
 #endif
 #else
   return u64;


### PR DESCRIPTION
Depending on platform and compiler, the line will give a warning:

error: operator '<<' has lower precedence than '+'; '+' will be evaluated first [-Werror,-Wshift-op-parentheses]

This is the right thing, but placing the parentheses makes the ordering explicit.