### PR TITLE
Change implicit NULL char conversion to explicit \0 char

### DIFF
--- a/code/dep_external/src/binaural/iamf2bear/iamf2bear.cpp
+++ b/code/dep_external/src/binaural/iamf2bear/iamf2bear.cpp
@@ -104,7 +104,7 @@ static int getmodulepath(char *path, int buffsize)
 #endif
   for (i = count - 1; i >= 0; --i) {
     if (path[i] == '\\' || path[i] == '/') {
-      path[i] = NULL;
+      path[i] = '\0';
       return (strlen(path));
     }
   }


### PR DESCRIPTION
```
error: implicit conversion of NULL constant to 'char' [-Werror,-Wnull-conversion]
```

We can avoid this warning by just explicitly setting the null char.