### PR TITLE
Add default case for non-exhaustive switch statement

### DIFF
--- a/code/src/iamf_dec/vlogging_tool_sr.c
+++ b/code/src/iamf_dec/vlogging_tool_sr.c
@@ -249,6 +249,8 @@ int write_postfix(LOG_TYPE type, char* buf) {
     case LOG_DECOP:
       len = sprintf(buf, "##\n");
       break;
+    default:
+      break;
   }
 
   return len;


### PR DESCRIPTION
This switch statement raises -Wswitch warning because it does not have cover all values of the enum and has no default.

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wswitch