### PR TITLE
tests/README.md: remove reference to decoded wav file.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,6 @@ several files associated with it.
 -   Standalone IAMF bitstream: `test_000012.iamf`.
 -   Fragmented MP4 file: `test_000012_f.mp4`.
 -   Standalone MP4 file: `test_000012_s.mp4`.
--   Decoded WAV file (per substream x): `test_000012_decoded_substream_x.wav`
 -   Rendered WAV file (per `mix_presentation_id` x, sub mix index y, layout
     index z): `test_000012_rendered_id_x_sub_mix_y_layout_z.wav`
 


### PR DESCRIPTION
These were dropped in https://github.com/AOMediaCodec/libiamf/pull/107.