### PR TITLE
Bump GitHub CI macos-12 to macos-13, due to upstream deprecation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           build-options: -DCODEC_CAP=off
   macos-amd64:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
See [GitHub's deprecation plan](actions/runner-images#10721)