### PR TITLE
Arm: Speed up samplewise matrix multiplication of channels

### DIFF
--- a/code/src/iamf_dec/IAMF_decoder.c
+++ b/code/src/iamf_dec/IAMF_decoder.c
@@ -2905,14 +2905,15 @@ void iamf_stream_renderer_close(IAMF_StreamRenderer *sr) {
 
 /**
  * @brief     Rendering an Audio Element.
+ * @param     [in] arch : architecture-specific callbacks.
  * @param     [in] sr : stream render handle.
  * @param     [in] in : input audio pcm
  * @param     [in] out : output audio pcm
  * @param     [in] frame_size : the size of audio frame.
  * @return    the number of rendering samples
  */
-static int iamf_stream_render(IAMF_StreamRenderer *sr, float *in, float *out,
-                              int frame_size) {
+static int iamf_stream_render(const Arch *arch, IAMF_StreamRenderer *sr,
+                              float *in, float *out, int frame_size) {
   IAMF_Stream *stream = sr->stream;
   int inchs;
   int outchs = stream->final_layout->channels;
@@ -2950,11 +2951,11 @@ static int iamf_stream_render(IAMF_StreamRenderer *sr, float *in, float *out,
                            frame_size - sr->offset, frame_size);
     } else {
       if (iamf_audio_layer_get_layout_info(ctx->layout)->rendering_id_in) {
-        IAMF_element_renderer_render_M2M(&sr->renderer.mmm, sin, sout,
+        IAMF_element_renderer_render_M2M(arch, &sr->renderer.mmm, sin, sout,
                                          frame_size);
       } else {
-        IAMF_element_renderer_render_M2M_custom(&sr->renderer.mmm, sin, sout,
-                                                frame_size,
+        IAMF_element_renderer_render_M2M_custom(arch, &sr->renderer.mmm, sin,
+                                                sout, frame_size,
                                                 sr->renderer.in_channel_map);
       }
     }
@@ -2967,8 +2968,8 @@ static int iamf_stream_render(IAMF_StreamRenderer *sr, float *in, float *out,
                                        frame_size);
     } else {
 #endif
-      IAMF_element_renderer_render_H2M(&sr->renderer.hmm, sin, sout, frame_size,
-                                       &sr->renderer.layout->lfe_f);
+      IAMF_element_renderer_render_H2M(arch, &sr->renderer.hmm, sin, sout,
+                                       frame_size, &sr->renderer.layout->lfe_f);
 #if ENABLE_HOA_TO_BINAURAL
     }
 #endif
@@ -3795,7 +3796,7 @@ static int iamf_decoder_internal_decode(IAMF_DecoderHandle handle,
 
           renderer->offset = decoder->delay > 0 ? decoder->delay : 0;
           if (stream->trimming_start) renderer->offset = 0;
-          iamf_stream_render(renderer, f->data, out, ret);
+          iamf_stream_render(handle->arch, renderer, f->data, out, ret);
 
 #if SR
           // rendering

--- a/code/src/iamf_dec/ae_rdr.h
+++ b/code/src/iamf_dec/ae_rdr.h
@@ -22,6 +22,8 @@
 
 #include <stdint.h>
 
+#include "arch.h"
+
 #define BS2051_MAX_CHANNELS 24  // BS2051_H
 typedef enum {
   BS2051_A = 0x020,        // 2ch output
@@ -208,23 +210,27 @@ int IAMF_element_renderer_get_M2M_custom_matrix(IAMF_SP_LAYOUT *in,
 
 /**
  * @brief     Predefined Multichannel to Multichannel Renderer.
+ * @param     [in] arch : architecture-specific callbacks.
  * @param     [in] in : the pcm signal of input.
  * @param     [in] out : the pcm signal of output
  * @param     [in] nsamples : the processed samples of pcm signal.
  * @return    @0: success,@others: fail
  */
-int IAMF_element_renderer_render_M2M(struct m2m_rdr_t *m2mMatrix, float *in[],
+int IAMF_element_renderer_render_M2M(const Arch *arch,
+                                     struct m2m_rdr_t *m2mMatrix, float *in[],
                                      float *out[], int nsamples);
 
 /**
  * @brief     Custom Multichannel to Multichannel Renderer.
+ * @param     [in] arch : architecture-specific callbacks.
  * @param     [in] in : the pcm signal of input.
  * @param     [in] out : the pcm signal of output
  * @param     [in] nsamples : the processed samples of pcm signal.
  * @param     [in] chmap : speaker subset channel list in input layout.
  * @return    @0: success,@others: fail
  */
-int IAMF_element_renderer_render_M2M_custom(struct m2m_rdr_t *m2mMatrix,
+int IAMF_element_renderer_render_M2M_custom(const Arch *arch,
+                                            struct m2m_rdr_t *m2mMatrix,
                                             float *in[], float *out[],
                                             int nsamples, int *chmap);
 // HOA to Multichannel
@@ -246,13 +252,15 @@ int IAMF_element_renderer_get_H2M_matrix(IAMF_HOA_LAYOUT *in,
 
 /**
  * @brief     Hoa to Multichannel Renderer.
+ * @param     [in] arch : architecture-specific callbacks.
  * @param     [in] in : the pcm signal of input.
  * @param     [in] out : the pcm signal of output
  * @param     [in] nsamples : the processed samples of pcm signal.
  * @param     [in] lfe : the filter to prcoess lfe channel.
  * @return    @0: success,@others: fail
  */
-int IAMF_element_renderer_render_H2M(struct h2m_rdr_t *h2mMatrix, float *in[],
+int IAMF_element_renderer_render_H2M(const Arch *arch,
+                                     struct h2m_rdr_t *h2mMatrix, float *in[],
                                      float *out[], int nsamples,
                                      lfe_filter_t *lfe);
 

--- a/code/src/iamf_dec/arch.h
+++ b/code/src/iamf_dec/arch.h
@@ -22,6 +22,12 @@
 
 typedef struct ArchCallbacks {
   // Functions with possible architecture-specific optimizations
+  struct {
+    void (*multiply_channels_by_matrix)(float *mat, int in_dim, int in_next,
+                                        int *in_idx_map, int out_dim,
+                                        int out_next, float **in, float **out,
+                                        int nsamples);
+  } rendering;
 } Arch;
 
 Arch *arch_create();

--- a/code/src/iamf_dec/arch/arch_common.c
+++ b/code/src/iamf_dec/arch/arch_common.c
@@ -19,4 +19,25 @@
 
 #include "arch_common.h"
 
-// TODO: Remove this line when first function added!
+void multiply_channels_by_matrix_c(float *mat, int in_dim, int in_next,
+                                   int *in_idx_map, int out_dim, int out_next,
+                                   float **in, float **out, int nsamples) {
+  int i, in_idx, out_idx;
+
+  if (in_dim <= 0 || out_dim <= 0) return;
+
+  for (in_idx = 0; in_idx < in_dim; in_idx++) {
+    const int in_mapped_idx = in_idx_map ? in_idx_map[in_idx] : in_idx;
+
+    for (out_idx = 0; out_idx < out_dim; out_idx++) {
+      const float c = mat[out_idx * out_next + in_mapped_idx * in_next];
+
+      for (i = 0; i < nsamples; i++) {
+        if (in_idx == 0) {
+          out[out_idx][i] = 0;
+        }
+        out[out_idx][i] += c * in[in_idx][i];
+      }
+    }
+  }
+}

--- a/code/src/iamf_dec/arch/arch_common.h
+++ b/code/src/iamf_dec/arch/arch_common.h
@@ -20,6 +20,8 @@
 #ifndef ARCH_COMMON_H_
 #define ARCH_COMMON_H_
 
-// TODO: Remove this line when first function added!
+void multiply_channels_by_matrix_c(float *mat, int in_dim, int in_next,
+                                   int *in_idx_map, int out_dim, int out_next,
+                                   float **in, float **out, int nsamples);
 
 #endif /* ARCH_COMMON_H_ */

--- a/code/src/iamf_dec/arch/arch_init.c
+++ b/code/src/iamf_dec/arch/arch_init.c
@@ -46,9 +46,7 @@ void arch_init(Arch* arch) {
   memset(arch, 0x0, sizeof(Arch));
 
   // Fill with reference implementations
-
-  // arch->myfn = &myfn_c; // myfn_c is in arch_common.h/.c
-  // TODO: Remove these lines when first function added!
+  arch->rendering.multiply_channels_by_matrix = &multiply_channels_by_matrix_c;
 
 #if defined(HAS_ARCH_OVERRIDE)
   // Override with platform-specific functions, if available

--- a/code/src/iamf_dec/arch/arm/arm_multiply_channels.c
+++ b/code/src/iamf_dec/arch/arm/arm_multiply_channels.c
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2024, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 3-Clause Clear License
+ * and the Alliance for Open Media Patent License 1.0. If the BSD 3-Clause Clear
+ * License was not distributed with this source code in the LICENSE file, you
+ * can obtain it at www.aomedia.org/license/software-license/bsd-3-c-c. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * www.aomedia.org/license/patent.
+ */
+
+/**
+ * @file arm_multiply_channels.c
+ * @brief Arm implementation for multiplying channels.
+ * @version 0.1
+ * @date Created 10/24/2024
+ **/
+
+#include "arm_multiply_channels.h"
+
+#if defined(IAMF_ARCH_DETECTED_ARM)
+
+#include <arm_neon.h>
+
+#if defined(__aarch64__)
+#define USE_16_ACCUMULATORS (1)
+#endif
+
+void multiply_channels_by_matrix_neon(float* mat, int in_dim, int in_next,
+                                      int* in_idx_map, int out_dim,
+                                      int out_next, float** in, float** out,
+                                      int nsamples) {
+  int i = 0, out_idx, in_idx;
+
+  if (in_dim <= 0 || out_dim <= 0) return;
+#ifdef USE_16_ACCUMULATORS
+  const int BLOCK_SIZE = 32;
+#else
+  const int BLOCK_SIZE = 16;
+#endif
+
+  const int blocked_size = nsamples / BLOCK_SIZE * BLOCK_SIZE;
+
+  for (i = 0; i < blocked_size; i += BLOCK_SIZE) {
+    for (out_idx = 0; out_idx < (out_dim & ~1); out_idx += 2) {
+      float* outPtr_a = out[out_idx + 0] + i;
+      float* outPtr_b = out[out_idx + 1] + i;
+
+      float32x4_t sum_a1 = vdupq_n_f32(0.0f);
+      float32x4_t sum_a2 = vdupq_n_f32(0.0f);
+      float32x4_t sum_a3 = vdupq_n_f32(0.0f);
+      float32x4_t sum_a4 = vdupq_n_f32(0.0f);
+#ifdef USE_16_ACCUMULATORS
+      float32x4_t sum_a5 = vdupq_n_f32(0.0f);
+      float32x4_t sum_a6 = vdupq_n_f32(0.0f);
+      float32x4_t sum_a7 = vdupq_n_f32(0.0f);
+      float32x4_t sum_a8 = vdupq_n_f32(0.0f);
+#endif
+
+      float32x4_t sum_b1 = vdupq_n_f32(0.0f);
+      float32x4_t sum_b2 = vdupq_n_f32(0.0f);
+      float32x4_t sum_b3 = vdupq_n_f32(0.0f);
+      float32x4_t sum_b4 = vdupq_n_f32(0.0f);
+#ifdef USE_16_ACCUMULATORS
+      float32x4_t sum_b5 = vdupq_n_f32(0.0f);
+      float32x4_t sum_b6 = vdupq_n_f32(0.0f);
+      float32x4_t sum_b7 = vdupq_n_f32(0.0f);
+      float32x4_t sum_b8 = vdupq_n_f32(0.0f);
+#endif
+
+      for (in_idx = 0; in_idx < in_dim; in_idx++) {
+        const int in_mapped_idx = in_idx_map ? in_idx_map[in_idx] : in_idx;
+        const int c_a_offset = out_idx * out_next + in_mapped_idx * in_next;
+        const int c_b_offset = c_a_offset + out_next;
+        const float* inPtr = in[in_idx] + i;
+
+        float32x4_t c_a = vld1q_dup_f32(&mat[c_a_offset]);
+        float32x4_t c_b = vld1q_dup_f32(&mat[c_b_offset]);
+
+        float32x4_t in_1 = vld1q_f32(inPtr + 0);
+        float32x4_t in_2 = vld1q_f32(inPtr + 4);
+        float32x4_t in_3 = vld1q_f32(inPtr + 8);
+        float32x4_t in_4 = vld1q_f32(inPtr + 12);
+#ifdef USE_16_ACCUMULATORS
+        float32x4_t in_5 = vld1q_f32(inPtr + 16);
+        float32x4_t in_6 = vld1q_f32(inPtr + 20);
+        float32x4_t in_7 = vld1q_f32(inPtr + 24);
+        float32x4_t in_8 = vld1q_f32(inPtr + 28);
+#endif
+
+        sum_a1 = vmlaq_f32(sum_a1, c_a, in_1);
+        sum_a2 = vmlaq_f32(sum_a2, c_a, in_2);
+        sum_a3 = vmlaq_f32(sum_a3, c_a, in_3);
+        sum_a4 = vmlaq_f32(sum_a4, c_a, in_4);
+#ifdef USE_16_ACCUMULATORS
+        sum_a5 = vmlaq_f32(sum_a5, c_a, in_5);
+        sum_a6 = vmlaq_f32(sum_a6, c_a, in_6);
+        sum_a7 = vmlaq_f32(sum_a7, c_a, in_7);
+        sum_a8 = vmlaq_f32(sum_a8, c_a, in_8);
+#endif
+
+        sum_b1 = vmlaq_f32(sum_b1, c_b, in_1);
+        sum_b2 = vmlaq_f32(sum_b2, c_b, in_2);
+        sum_b3 = vmlaq_f32(sum_b3, c_b, in_3);
+        sum_b4 = vmlaq_f32(sum_b4, c_b, in_4);
+#ifdef USE_16_ACCUMULATORS
+        sum_b5 = vmlaq_f32(sum_b5, c_b, in_5);
+        sum_b6 = vmlaq_f32(sum_b6, c_b, in_6);
+        sum_b7 = vmlaq_f32(sum_b7, c_b, in_7);
+        sum_b8 = vmlaq_f32(sum_b8, c_b, in_8);
+#endif
+      }
+
+      vst1q_f32(outPtr_a + 0, sum_a1);
+      vst1q_f32(outPtr_a + 4, sum_a2);
+      vst1q_f32(outPtr_a + 8, sum_a3);
+      vst1q_f32(outPtr_a + 12, sum_a4);
+#ifdef USE_16_ACCUMULATORS
+      vst1q_f32(outPtr_a + 16, sum_a5);
+      vst1q_f32(outPtr_a + 20, sum_a6);
+      vst1q_f32(outPtr_a + 24, sum_a7);
+      vst1q_f32(outPtr_a + 28, sum_a8);
+#endif
+
+      vst1q_f32(outPtr_b + 0, sum_b1);
+      vst1q_f32(outPtr_b + 4, sum_b2);
+      vst1q_f32(outPtr_b + 8, sum_b3);
+      vst1q_f32(outPtr_b + 12, sum_b4);
+#ifdef USE_16_ACCUMULATORS
+      vst1q_f32(outPtr_b + 16, sum_b5);
+      vst1q_f32(outPtr_b + 20, sum_b6);
+      vst1q_f32(outPtr_b + 24, sum_b7);
+      vst1q_f32(outPtr_b + 28, sum_b8);
+#endif
+    }
+
+    if (out_dim & 1) {
+      out_idx = out_dim - 1;
+      float* outPtr = out[out_idx] + i;
+
+      float32x4_t sum_1 = vdupq_n_f32(0.0f);
+      float32x4_t sum_2 = vdupq_n_f32(0.0f);
+      float32x4_t sum_3 = vdupq_n_f32(0.0f);
+      float32x4_t sum_4 = vdupq_n_f32(0.0f);
+#ifdef USE_16_ACCUMULATORS
+      float32x4_t sum_5 = vdupq_n_f32(0.0f);
+      float32x4_t sum_6 = vdupq_n_f32(0.0f);
+      float32x4_t sum_7 = vdupq_n_f32(0.0f);
+      float32x4_t sum_8 = vdupq_n_f32(0.0f);
+#endif
+
+      for (in_idx = 0; in_idx < in_dim; in_idx++) {
+        const int in_mapped_idx = in_idx_map ? in_idx_map[in_idx] : in_idx;
+        const int c_offset = out_idx * out_next + in_mapped_idx * in_next;
+        const float* inPtr = in[in_idx] + i;
+
+        float32x4_t c = vld1q_dup_f32(&mat[c_offset]);
+
+        float32x4_t in_1 = vld1q_f32(inPtr + 0);
+        float32x4_t in_2 = vld1q_f32(inPtr + 4);
+        float32x4_t in_3 = vld1q_f32(inPtr + 8);
+        float32x4_t in_4 = vld1q_f32(inPtr + 12);
+#ifdef USE_16_ACCUMULATORS
+        float32x4_t in_5 = vld1q_f32(inPtr + 16);
+        float32x4_t in_6 = vld1q_f32(inPtr + 20);
+        float32x4_t in_7 = vld1q_f32(inPtr + 24);
+        float32x4_t in_8 = vld1q_f32(inPtr + 28);
+#endif
+
+        sum_1 = vmlaq_f32(sum_1, c, in_1);
+        sum_2 = vmlaq_f32(sum_2, c, in_2);
+        sum_3 = vmlaq_f32(sum_3, c, in_3);
+        sum_4 = vmlaq_f32(sum_4, c, in_4);
+#ifdef USE_16_ACCUMULATORS
+        sum_5 = vmlaq_f32(sum_5, c, in_5);
+        sum_6 = vmlaq_f32(sum_6, c, in_6);
+        sum_7 = vmlaq_f32(sum_7, c, in_7);
+        sum_8 = vmlaq_f32(sum_8, c, in_8);
+#endif
+      }
+      vst1q_f32(outPtr + 0, sum_1);
+      vst1q_f32(outPtr + 4, sum_2);
+      vst1q_f32(outPtr + 8, sum_3);
+      vst1q_f32(outPtr + 12, sum_4);
+#ifdef USE_16_ACCUMULATORS
+      vst1q_f32(outPtr + 16, sum_5);
+      vst1q_f32(outPtr + 20, sum_6);
+      vst1q_f32(outPtr + 24, sum_7);
+      vst1q_f32(outPtr + 28, sum_8);
+#endif
+    }
+  }
+
+  for (in_idx = 0; in_idx < in_dim; in_idx++) {
+    const int in_mapped_idx = in_idx_map ? in_idx_map[in_idx] : in_idx;
+
+    for (out_idx = 0; out_idx < out_dim; out_idx++) {
+      const float c = mat[out_idx * out_next + in_mapped_idx * in_next];
+
+      for (i = blocked_size; i < nsamples; i++) {
+        if (in_idx == 0) {
+          out[out_idx][i] = 0;
+        }
+        out[out_idx][i] += c * in[in_idx][i];
+      }
+    }
+  }
+}
+
+#endif /* IAMF_ARCH_DETECTED_ARM */

--- a/code/src/iamf_dec/arch/arm/arm_multiply_channels.h
+++ b/code/src/iamf_dec/arch/arm/arm_multiply_channels.h
@@ -11,26 +11,23 @@
  */
 
 /**
- * @file override_arm.c
- * @brief Override with Arm function implementations.
+ * @file arm_multiply_channels.h
+ * @brief Arm implementation for multiplying channels.
  * @version 0.1
  * @date Created 10/24/2024
  **/
+
+#ifndef ARM_MULTIPLY_CHANNELS_H_
+#define ARM_MULTIPLY_CHANNELS_H_
 
 #include "detect_arm.h"
 
 #if defined(IAMF_ARCH_DETECTED_ARM)
 
-#include <arm_neon.h>
+void multiply_channels_by_matrix_neon(float *mat, int in_dim, int in_next,
+                                      int *in_idx_map, int out_dim,
+                                      int out_next, float **in, float **out,
+                                      int nsamples);
 
-#include "../../arch.h"
-#include "arm_multiply_channels.h"
-
-void arch_override(Arch *arch) {
-  // Override functions with Arm implementations here
-
-  arch->rendering.multiply_channels_by_matrix =
-      &multiply_channels_by_matrix_neon;
-}
-
-#endif
+#endif /* IAMF_ARCH_DETECTED_ARM */
+#endif /* ARM_MULTIPLY_CHANNELS_H_ */

--- a/code/src/iamf_dec/h2m_rdr.c
+++ b/code/src/iamf_dec/h2m_rdr.c
@@ -2098,11 +2098,11 @@ static float lfefilter_update(lfe_filter_t *lfe_f, float input);
 #endif
 
 // HOA to Multichannel Renderer
-int IAMF_element_renderer_render_H2M(struct h2m_rdr_t *h2mMatrix, float *in[],
+int IAMF_element_renderer_render_H2M(const Arch *arch,
+                                     struct h2m_rdr_t *h2mMatrix, float *in[],
                                      float *out[], int nsamples,
                                      lfe_filter_t *lfe) {
-  int i, j, m, n;
-  int m_size = h2mMatrix->m;
+  int i, j, n;
   int n_size = h2mMatrix->n;
 
   // lfe generator turns on
@@ -2114,16 +2114,9 @@ int IAMF_element_renderer_render_H2M(struct h2m_rdr_t *h2mMatrix, float *in[],
   };
 
   /// convert HOA to channel by using the predefined matrix
-  for (i = 0; i < nsamples; i++) {
-    for (n = 0; n < n_size; n++) {    // output
-      for (m = 0; m < m_size; m++) {  // input
-        if (m == 0) {
-          out[n][i] = 0;  // initialize output sample
-        }
-        out[n][i] += h2mMatrix->mat[n * m_size + m] * in[m][i];
-      }
-    }
-  }
+  (*arch->rendering.multiply_channels_by_matrix)(
+      h2mMatrix->mat, h2mMatrix->m, 1, 0, h2mMatrix->n, h2mMatrix->m, in, out,
+      nsamples);
 
   n = 0;
   if (lfe1 >= 0 || lfe2 >= 0) {

--- a/code/src/iamf_dec/m2m_rdr.c
+++ b/code/src/iamf_dec/m2m_rdr.c
@@ -1455,49 +1455,24 @@ int IAMF_element_renderer_get_M2M_custom_matrix(IAMF_SP_LAYOUT *in_layout,
 }
 
 // Predefined Multichannel to Multichannel Renderer
-int IAMF_element_renderer_render_M2M(struct m2m_rdr_t *m2mMatrix, float *in[],
+int IAMF_element_renderer_render_M2M(const Arch *arch,
+                                     struct m2m_rdr_t *m2mMatrix, float *in[],
                                      float *out[], int nsamples) {
-  int i, m, n;
-  int m_size = m2mMatrix->m;
-  int n_size = m2mMatrix->n;
-
-  for (i = 0; i < nsamples; i++) {
-    for (m = 0; m < m_size; m++)  // input
-    {
-      for (n = 0; n < n_size; n++)  // output
-      {
-        if (m == 0) {
-          out[n][i] = 0;
-        }
-        out[n][i] += m2mMatrix->mat[m * n_size + n] * in[m][i];
-      }
-    }
-  }
+  (*arch->rendering.multiply_channels_by_matrix)(m2mMatrix->mat, m2mMatrix->m,
+                                                 m2mMatrix->n, 0, m2mMatrix->n,
+                                                 1, in, out, nsamples);
 
   return (0);
 }
 
 // Custom Multichannel to Multichannel Renderer
-int IAMF_element_renderer_render_M2M_custom(struct m2m_rdr_t *m2mMatrix,
+int IAMF_element_renderer_render_M2M_custom(const Arch *arch,
+                                            struct m2m_rdr_t *m2mMatrix,
                                             float *in[], float *out[],
                                             int nsamples, int *chmap) {
-  int i, m, n, m2;
-  int m_size = m2mMatrix->m;
-  int n_size = m2mMatrix->n;
-
-  for (i = 0; i < nsamples; i++) {
-    for (m = 0; m < m_size; m++)  // input
-    {
-      for (n = 0; n < n_size; n++)  // output
-      {
-        if (m == 0) {
-          out[n][i] = 0;
-        }
-        m2 = chmap[m];
-        out[n][i] += m2mMatrix->mat[m2 * n_size + n] * in[m][i];
-      }
-    }
-  }
+  (*arch->rendering.multiply_channels_by_matrix)(
+      m2mMatrix->mat, m2mMatrix->m, m2mMatrix->n, chmap, m2mMatrix->n, 1, in,
+      out, nsamples);
 
   return (0);
 }

--- a/code/win64/VS2022/iamf/iamf.vcxproj
+++ b/code/win64/VS2022/iamf/iamf.vcxproj
@@ -135,6 +135,7 @@
     <ClCompile Include="..\..\..\src\iamf_dec\aac\IAMF_aac_decoder.c" />
     <ClCompile Include="..\..\..\src\iamf_dec\arch\arch_init.c" />
     <ClCompile Include="..\..\..\src\iamf_dec\arch\arch_common.c" />
+    <ClCompile Include="..\..\..\src\iamf_dec\arch\arm\arm_multiply_channels.c" />
     <ClCompile Include="..\..\..\src\iamf_dec\arch\arm\override_arm.c" />
     <ClCompile Include="..\..\..\src\iamf_dec\arch\x86\override_x86.c" />
     <ClCompile Include="..\..\..\src\iamf_dec\arch.c" />
@@ -174,6 +175,7 @@
     <ClInclude Include="..\..\..\src\iamf_dec\ae_rdr.h" />
     <ClCompile Include="..\..\..\src\iamf_dec\arch\arch_init.h" />
     <ClCompile Include="..\..\..\src\iamf_dec\arch\arch_common.h" />
+    <ClCompile Include="..\..\..\src\iamf_dec\arch\arm\arm_multiply_channels.h" />
     <ClCompile Include="..\..\..\src\iamf_dec\arch\arm\detect_arm.h" />
     <ClCompile Include="..\..\..\src\iamf_dec\arch\x86\detect_x86.h" />
     <ClCompile Include="..\..\..\src\iamf_dec\arch.h" />

--- a/code/win64/VS2022/iamf/iamf.vcxproj.filters
+++ b/code/win64/VS2022/iamf/iamf.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClCompile Include="..\..\..\src\iamf_dec\arch\arch_common.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\iamf_dec\arch\arm\arm_multiply_channels.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\src\iamf_dec\arch\arm\override_arm.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -138,6 +141,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\iamf_dec\arch\arch_common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\iamf_dec\arch\arm\arm_multiply_channels.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\iamf_dec\arch\arm\detect_arm.h">


### PR DESCRIPTION
Extract samplewise matrix multiplication of channels (used in loudspeaker renderers) as a function with C and Neon implementations.