### PR TITLE
bugfix: control_point_relative_time is converted from uint_8 to float…

### DIFF
--- a/code/src/common/fixedp11_5.c
+++ b/code/src/common/fixedp11_5.c
@@ -23,6 +23,10 @@ float q_to_float(q16_t q, int frac) {
   return ((float)q) * powf(2.0f, (float)-frac);
 }
 
+float qf2float(qf_t qf, int frac) {
+  return ((float)qf / (pow(2.0f, (float)frac)));
+}
+
 float qf_to_float(qf_t qf, int frac) {
   return ((float)qf / (pow(2.0f, (float)frac) - 1.0));  // f = q / 255
 }

--- a/code/src/common/fixedp11_5.h
+++ b/code/src/common/fixedp11_5.h
@@ -33,6 +33,9 @@ typedef uint8_t qf_t;
 float q_to_float(q16_t q, int frac);
 
 /// Converts between double and q8_t
+// qf/2^frac
+float qf2float(qf_t qf, int frac);
+// q/(2^frac - 1)
 float qf_to_float(qf_t q, int frac);
 
 float db2lin(float db);

--- a/code/src/iamf_dec/IAMF_OBU.c
+++ b/code/src/iamf_dec/IAMF_OBU.c
@@ -1195,7 +1195,7 @@ IAMF_Parameter *iamf_parameter_new(IAMF_OBU *obu,
             mg->mix_gain_f.control = db2lin(gain1_db);
             mg->mix_gain.control_relative_time = bs_getA8b(&b);
             mg->mix_gain_f.control_relative_time =
-                qf_to_float(mg->mix_gain.control_relative_time, 8);
+                qf2float(mg->mix_gain.control_relative_time, 8);
             ia_logd("\t mix gain seg %d: interval %" PRIu64
                     ", bezier, start %f (%fdb "
                     "<0x%02x>), end %f (%fdb <0x%02x>), control %f (%fdb "


### PR DESCRIPTION
… type and needs to be divided by 256 instead of 255