### PR TITLE
Bump GitHub CI macos-13 to macos-14, due to imminent upstream depreca…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           build-options: -DCODEC_CAP=off
   macos-amd64:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
…tion.

  - [GitHub's deprecation announcement plan](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down) recommend switching to macos-14.
  - Bump up to the next supported version.