### PR TITLE
tests: find binaural goldens named <prefix>_rendered_binaural.wav

### DIFF
--- a/tests/user_metadata_parsing_utils.py
+++ b/tests/user_metadata_parsing_utils.py
@@ -148,6 +148,20 @@ def get_test_combination_metadata(user_metadata_proto, test_file_directory):
         golden_wav_path = os.path.join(
             test_file_directory, golden_wav_file_name
         )
+        # Some vectors store the binaural render under a layout-agnostic name
+        # (`<prefix>_rendered_binaural.wav`) instead of the
+        # `_rendered_id_..._layout_N.wav` convention. Fall back to it for
+        # binaural layouts so those vectors are not silently skipped.
+        if (
+            not os.path.exists(golden_wav_path)
+            and layout.loudness_layout.layout_type
+            == mix_presentation_pb2.LAYOUT_TYPE_BINAURAL
+        ):
+          alt_file_name = f'{file_name_prefix}_rendered_binaural.wav'
+          alt_path = os.path.join(test_file_directory, alt_file_name)
+          if os.path.exists(alt_path):
+            golden_wav_file_name = alt_file_name
+            golden_wav_path = alt_path
         bit_depth = 16
         sample_rate = 48000
         if os.path.exists(golden_wav_path):


### PR DESCRIPTION
## Problem

`get_test_combination_metadata()` builds golden filenames in only one form:

```
<prefix>_rendered_id_<id>_sub_mix_<n>_layout_<n>.wav
```

Several binaural test vectors instead ship their reference render under a
layout-agnostic name, `<prefix>_rendered_binaural.wav`. For those the harness
takes the `else` branch, logs

```
Warning: golden wav file not found, sometimes this is because the mix
presentation is invalid to decode: ...
```

and `continue`s — so the layout is skipped entirely, **even when
`--test_binaural` is passed**. The warning is easily read as "this vector is
not valid to decode", which is why the gap went unnoticed.

Affected vectors: `test_000812`, `test_000825`, `test_000826`, `test_000912`,
`test_000925`, `test_000931`, `test_001013`, `test_001100`–`test_001103` —
11 in total, covering object-based, advanced-profile, expanded-layout, and the
binaural rendering-mode / filter-profile cases.

## Fix

When the layout-indexed golden does not exist **and** the layout is
`LAYOUT_TYPE_BINAURAL`, fall back to `<prefix>_rendered_binaural.wav` if that
file is present.

The fallback is gated so it can only rescue a case that previously bailed out:

- non-binaural layouts are untouched;
- `test_000095` / `test_000096`, whose binaural goldens already use the
  layout-indexed convention, are untouched because the primary path exists and
  the first condition short-circuits.

Because `golden_wav_file_name` is reassigned before `TestCombinationMetadata`
is constructed, `base_name_to_generate` follows it, so the `-o3` output path
given to `iamfdec` and the reference used by `compute_metrics()` stay
consistent. `bit_depth` and `sample_rate` are read from the file actually being
compared against.

## Effect

The 11 vectors above now participate in the PSNR comparison under
`--test_binaural`; at the currently pinned OAR revision
(`3d1d23b807543f993a1d0cf0a9839c7f0746d94b`) they all score ~99 dB. Default
runs are unchanged — binaural remains opt-in via `--test_binaural`
(`run_decode_and_psnr_test.py:261`).

## Note on the naming assumption

The fallback assumes at most one binaural render per test-vector prefix. That
holds across the current corpus: of 333 textprotos, 13 declare
`LAYOUT_TYPE_BINAURAL` and none declares more than one. If a future vector ever
carries two binaural layouts, both combinations would resolve to the same
golden and the same generated filename; a guard can be added at that point, or
now if reviewers prefer.

## Relevance to #175

This also makes the discussion in #175 verifiable. Six of the vectors this PR
un-skips — `test_000812`, `test_000825`, `test_000826`, `test_000912`,
`test_000925`, `test_000931` — are exactly the ones reported there as changing
when OAR is advanced past the pinned revision. Until the harness can see them,
any regeneration of those reference files cannot be checked by the suite.
